### PR TITLE
Allow modification of tf2 install directory

### DIFF
--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -1,15 +1,32 @@
 #!/bin/bash
+
+set -e # Exit on command fail
+set -o pipefail # Don't conceal errors in pipes
+set -u # Exit if there are unset variables
+
+installDir="${STEAMAPPDIR}"
+
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -d|--directory) installDir="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
+
 bash "${STEAMCMDDIR}/steamcmd.sh" +login anonymous \
-                                +force_install_dir "${STEAMAPPDIR}" \
+                                +force_install_dir "${installDir}" \
                                 +app_update "${STEAMAPPID}" \
                                 +quit
 
+sed -i -e "s|^force_install_dir..*|force_install_dir ${installDir}|"
+
 # Change hostname on first launch (you can comment this out if it has done it's purpose)
-sed -i -e 's/{{SERVER_HOSTNAME}}/'"${SRCDS_HOSTNAME}"'/g' "${STEAMAPPDIR}/${STEAMAPP}/cfg/server.cfg"
+sed -i -e 's/{{SERVER_HOSTNAME}}/'"${SRCDS_HOSTNAME}"'/g' "${installDir}/${STEAMAPP}/cfg/server.cfg"
 
 bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         -steam_dir "${STEAMCMDDIR}" \
-                        -steamcmd_script "${STEAMAPPDIR}/${STEAMAPP}_update.txt" \
+                        -steamcmd_script "${installDir}/${STEAMAPP}_update.txt" \
                         -usercon \
                         +fps_max "${SRCDS_FPSMAX}" \
                         -tickrate "${SRCDS_TICKRATE}" \


### PR DESCRIPTION
This lets users modify the entry point in descendant images to specify where to install TF2, which enables the use of volumes.