### PR TITLE
added -it option for docker run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ This Docker image contains the dedicated server of the game.
 
 Running on the *host* interface (recommended):<br/>
 ```console
-$ docker run -d --net=host --name=tf2-dedicated -e SRCDS_TOKEN={YOURTOKEN} cm2network/tf2
+$ docker run -d -it --net=host --name=tf2-dedicated -e SRCDS_TOKEN={YOURTOKEN} cm2network/tf2
 ```
 
 Running using a bind mount for data persistence on container recreation:
 ```console
 $ mkdir -p $(pwd)/tf2-data
 $ chmod 777 $(pwd)/tf2-data # Makes sure the directory is writeable by the unprivileged container user
-$ docker run -d --net=host -v $(pwd)/tf2-data:/home/steam/tf-dedicated/ --name=tf2-dedicated -e SRCDS_TOKEN={YOURTOKEN} cm2network/tf2
+$ docker run -d -it --net=host -v $(pwd)/tf2-data:/home/steam/tf-dedicated/ --name=tf2-dedicated -e SRCDS_TOKEN={YOURTOKEN} cm2network/tf2
 ```
 
 Running multiple instances (increment SRCDS_PORT and SRCDS_TV_PORT):
 ```console
-$ docker run -d --net=host --name=tf2-dedicated2 -e SRCDS_PORT=27016 -e SRCDS_TV_PORT=27021 -e SRCDS_TOKEN={YOURTOKEN} cm2network/tf2
+$ docker run -d -it --net=host --name=tf2-dedicated2 -e SRCDS_PORT=27016 -e SRCDS_TV_PORT=27021 -e SRCDS_TOKEN={YOURTOKEN} cm2network/tf2
 ```
 
 `SRCDS_TOKEN` **is required to be listed & reachable;** [https://steamcommunity.com/dev/managegameservers](https://steamcommunity.com/dev/managegameservers)<br/><br/>


### PR DESCRIPTION
fixed #11 .

It seems that the tty was not allocated and the stdout was missing.

good server
```
steam@primary:~$ ps auxfwww
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
steam       92  0.0  0.3   4000  3288 pts/1    Ss   06:58   0:00 bash
steam      107  0.0  0.2   7640  2716 pts/1    R+   07:01   0:00  \_ ps auxfwww
steam        1  0.0  0.0   3736     8 pts/0    Ss+  Sep30   0:00 bash entry.sh
steam       30  0.0  0.0   4000     8 pts/0    S+   Sep30   0:00 bash /home/steam/tf-dedicated/srcds_run -game tf -console -autoupdate -steam_dir /home/steam/steamcmd -steamcmd_script /home/steam/tf_update.txt -usercon +fps_max 300 -tickrate 66 -port 27015 +tv_port 27020 +clientport  +maxplayers 24 +map koth_sawmill +sv_setsteamaccount xxx +net_public_adr 153.126.149.119 -ip 0.0.0.0 +rcon_password xxx
steam       56  1.7 32.4 751804 327788 pts/0   Sl+  Sep30  11:17  \_ ./srcds_linux -game tf -console -autoupdate -steam_dir /home/steam/steamcmd -steamcmd_script /home/steam/tf_update.txt -usercon +fps_max 300 -tickrate 66 -port 27015 +tv_port 27020 +clientport +maxplayers 24 +map koth_sawmill +sv_setsteamaccount xxx +net_public_adr 153.126.149.119 -ip 0.0.0.0 +rcon_password xxx
```

problem server
```
steam@secondary:~$ ls -al /dev/stdout /proc/self/fd/1
lrwxrwxrwx 1 root  root  15 Sep 29 18:16 /dev/stdout -> /proc/self/fd/1
lrwx------ 1 steam steam 64 Oct  1 07:02 /proc/self/fd/1 -> /dev/pts/0
steam@secondary:~$ ps auxfwww
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
steam      553  0.5  0.3   4000  3276 pts/0    Ss   07:02   0:00 bash
steam      562  0.0  0.2   7640  2792 pts/0    R+   07:02   0:00  \_ ps auxfwww
steam        1  0.0  0.0   3736     8 ?        Ss   Sep29   0:00 bash entry.sh
steam       30  0.0  0.0   4000     8 ?        S    Sep29   0:00 bash /home/steam/tf-dedicated/srcds_run -game tf -console -autoupdate -steam_dir /home/steam/steamcmd -steamcmd_script /home/steam/tf_update.txt -usercon +fps_max 300 -tickrate 66 -port 27015 +tv_port 27020 +clientport  +maxplayers 16 +map ctf_2fort +sv_setsteamaccount xxx +rcon_password changeme +sv_password changeme +sv_region 3 +net_public_adr 0 -ip 0 +host_workshop_collection 0 +workshop_start_map 0 -authkey
steam       56  2.2 15.6 772992 157688 ?       Sl   Sep29  49:56  \_ ./srcds_linux -game tf -console -autoupdate -steam_dir /home/steam/steamcmd -steamcmd_script /home/steam/tf_update.txt -usercon +fps_max 300 -tickrate 66 -port 27015 +tv_port 27020 +clientport +maxplayers 16 +map ctf_2fort +sv_setsteamaccount xxx +rcon_password changeme +sv_password changeme +sv_region 3 +net_public_adr 0 -ip 0 +host_workshop_collection 0 +workshop_start_map 0 -authkey
```

works fine.
```
ubuntu@secondary:~$ docker run -d -it --net=host --name=tf2-4 -e SRCDS_TOKEN=xxxxxx cm2network/tf2:sourcemod
ubuntu@secondary:~$ docker logs tf2-4 | tail
L 10/01/2021 - 07:19:39: server_cvar: "mp_stalemate_enable" "1"
L 10/01/2021 - 07:19:39: server_cvar: "mp_timelimit" "35"
L 10/01/2021 - 07:19:39: server_cvar: "decalfrequency" "30"
'ctf_2fort.cfg' not present; not executing.
Server is hibernating
Connection to Steam servers successful.
   Public IP to Steam is 153.127.49.53.
Assigned persistent gameserver Steam ID [G:1:4490238].
VAC secure mode is activated.
L 10/01/2021 - 07:19:39: server_cvar: "sm_nextmap" "tc_hydro"
steam@secondary:~$ ls -al /dev/stdout /proc/self/fd/1
lrwxrwxrwx 1 root  root  15 Oct  1 07:11 /dev/stdout -> /proc/self/fd/1
lrwx------ 1 steam steam 64 Oct  1 07:21 /proc/self/fd/1 -> /dev/pts/1
steam@secondary:~$ ps auxfwww
USER       PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
steam      490  0.1  0.3   4000  3116 pts/1    Ss   07:21   0:00 bash
steam      498  0.0  0.2   7640  2720 pts/1    R+   07:21   0:00  \_ ps auxfwww
steam        1  0.0  0.0   3736   104 pts/0    Ss+  07:11   0:00 bash entry.sh
steam      124  0.0  0.0   4000     4 pts/0    S+   07:19   0:00 bash /home/steam/tf-dedicated/srcds_run -game tf -console -autoupdate -steam_dir /home/steam/steamcmd -steamcmd_script /home/steam/tf_update.txt -usercon +fps_max 300 -tickrate 66 -port 27015 +tv_port 27020 +clientport  +maxplayers 16 +map ctf_2fort +sv_setsteamaccount xxxx +rcon_password changeme +sv_password changeme +sv_region 3 +net_public_adr 0 -ip 0 +host_workshop_collection 0 +workshop_start_map 0 -authkey
steam      150 10.2 48.3 761388 488084 pts/0   Sl+  07:19   0:15  \_ ./srcds_linux -game tf -console -autoupdate -steam_dir /home/steam/steamcmd -steamcmd_script /home/steam/tf_update.txt -usercon +fps_max 300 -tickrate 66 -port 27015 +tv_port 27020 +clientport +maxplayers 16 +map ctf_2fort +sv_setsteamaccount xxx +rcon_password changeme +sv_password changeme +sv_region 3 +net_public_adr 0 -ip 0 +host_workshop_collection 0 +workshop_start_map 0 -authkey
```

Maybe I unintentionally added -it when I created it a month ago...
```
ubuntu@primary:~$ docker inspect tf2-dedicated2 | grep -i tty
            "Tty": true,
```