### PR TITLE
Insecured + MapCycle + ServerCfg ENV variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ SRCDS_STARTMAP="ctf_2fort"
 SRCDS_HOSTNAME="New TF Server" (first launch only)
 SRCDS_WORKSHOP_AUTHKEY="" (required to load workshop maps)
 SRCDS_CFG="server.cfg"
-SRCDS_MAPCYCLE="mapcycle.txt"
+SRCDS_MAPCYCLE="mapcycle_default.txt" (value can be overwritten by tf/cfg/server.cfg)
 SRCDS_SECURED=1 (0 to start the server as insecured)
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ SRCDS_REGION=3
 SRCDS_STARTMAP="ctf_2fort"
 SRCDS_HOSTNAME="New TF Server" (first launch only)
 SRCDS_WORKSHOP_AUTHKEY="" (required to load workshop maps)
+SRCDS_CFG="server.cfg"
 ```
+
 ## Config
 The image contains static copies of the competitive config files from [UGC League](https://www.ugcleague.com/files_tf26.cfm#) and [RGL.gg](https://rgl.gg/Public/About/Configs.aspx?r=24). 
 
@@ -65,6 +67,7 @@ You can edit the config using this command:
 ```console
 $ docker exec -it tf2-dedicated nano /home/steam/tf-dedicated/tf/cfg/server.cfg
 ```
+Or if you want to explicitly specify a server config file, use the `SRCDS_CFG` environment variable.
 
 If you want to learn more about configuring a TF2 server check this [documentation](https://wiki.teamfortress.com/wiki/Dedicated_server_configuration).
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ SRCDS_STARTMAP="ctf_2fort"
 SRCDS_HOSTNAME="New TF Server" (first launch only)
 SRCDS_WORKSHOP_AUTHKEY="" (required to load workshop maps)
 SRCDS_CFG="server.cfg"
+SRCDS_MAPCYCLE="mapcycle.txt"
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ SRCDS_HOSTNAME="New TF Server" (first launch only)
 SRCDS_WORKSHOP_AUTHKEY="" (required to load workshop maps)
 SRCDS_CFG="server.cfg"
 SRCDS_MAPCYCLE="mapcycle.txt"
+SRCDS_SECURED=1 (0 to start the server as insecured)
 ```
 
 ## Config

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -57,7 +57,8 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_HOSTNAME="New \"${STEAMAPP}\" Server" \
         SRCDS_WORKSHOP_START_MAP=0 \
         SRCDS_HOST_WORKSHOP_COLLECTION=0 \
-        SRCDS_WORKSHOP_AUTHKEY=""
+        SRCDS_WORKSHOP_AUTHKEY="" \
+	SRCDS_CFG="server.cfg"
 
 # Switch to user
 USER ${USER}

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -59,7 +59,7 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_HOST_WORKSHOP_COLLECTION=0 \
         SRCDS_WORKSHOP_AUTHKEY="" \
 	SRCDS_CFG="server.cfg" \
-	SRCDS_MAPCYCLE="mapcycle.txt" \
+	SRCDS_MAPCYCLE="mapcycle_default.txt" \
 	SRCDS_SECURED=1
 
 # Switch to user

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -59,7 +59,8 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_HOST_WORKSHOP_COLLECTION=0 \
         SRCDS_WORKSHOP_AUTHKEY="" \
 	SRCDS_CFG="server.cfg" \
-	SRCDS_MAPCYCLE="mapcycle.txt"
+	SRCDS_MAPCYCLE="mapcycle.txt" \
+	SRCDS_SECURED=1
 
 # Switch to user
 USER ${USER}

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -58,7 +58,8 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_WORKSHOP_START_MAP=0 \
         SRCDS_HOST_WORKSHOP_COLLECTION=0 \
         SRCDS_WORKSHOP_AUTHKEY="" \
-	SRCDS_CFG="server.cfg"
+	SRCDS_CFG="server.cfg" \
+	SRCDS_MAPCYCLE="mapcycle.txt"
 
 # Switch to user
 USER ${USER}

--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -53,6 +53,6 @@ bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         +sv_region "${SRCDS_REGION}" \
                         -ip "${SRCDS_IP}" \
                         -authkey "${SRCDS_WORKSHOP_AUTHKEY}" \
-                        +servercfg "${SRCDS_CFG}" \
-                        +mapcycle "${SRCDS_MAPCYCLE}" \
+                        +servercfgfile "${SRCDS_CFG}" \
+                        +mapcyclefile "${SRCDS_MAPCYCLE}" \
                         ${SERVER_SECURITY_FLAG}

--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -46,4 +46,5 @@ bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         +sv_password "${SRCDS_PW}" \
                         +sv_region "${SRCDS_REGION}" \
                         -ip "${SRCDS_IP}" \
-                        -authkey "${SRCDS_WORKSHOP_AUTHKEY}"
+                        -authkey "${SRCDS_WORKSHOP_AUTHKEY}" \
+                        +servercfg "${SRCDS_CFG}"

--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -30,6 +30,12 @@ fi
 # Believe it or not, if you don't do this srcds_run shits itself
 cd "${STEAMAPPDIR}"
 
+SERVER_SECURITY_FLAG="-secured";
+
+if [ "$SRCDS_SECURED" -eq 0]; then
+        SERVER_SECURITY_FLAG="-insecured";
+fi
+
 bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         -steam_dir "${STEAMCMDDIR}" \
                         -steamcmd_script "${HOMEDIR}/${STEAMAPP}_update.txt" \
@@ -48,4 +54,5 @@ bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         -ip "${SRCDS_IP}" \
                         -authkey "${SRCDS_WORKSHOP_AUTHKEY}" \
                         +servercfg "${SRCDS_CFG}" \
-                        +mapcycle "${SRCDS_MAPCYCLE}"
+                        +mapcycle "${SRCDS_MAPCYCLE}" \
+                        ${SERVER_SECURITY_FLAG}

--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -47,4 +47,5 @@ bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         +sv_region "${SRCDS_REGION}" \
                         -ip "${SRCDS_IP}" \
                         -authkey "${SRCDS_WORKSHOP_AUTHKEY}" \
-                        +servercfg "${SRCDS_CFG}"
+                        +servercfg "${SRCDS_CFG}" \
+                        +mapcycle "${SRCDS_MAPCYCLE}"


### PR DESCRIPTION
This PR adds support for Insecured (#21), MapCycle (#19) and an additional ServerCfg ENV variables.

These features have not been tested yet, wait until doing so before merging.