### PR TITLE
feat: Fix server secured flag

### DIFF
--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -33,7 +33,7 @@ cd "${STEAMAPPDIR}"
 SERVER_SECURITY_FLAG="-secured";
 
 if [ "$SRCDS_SECURED" -eq 0]; then
-        SERVER_SECURITY_FLAG="-insecured";
+        SERVER_SECURITY_FLAG="-insecure";
 fi
 
 bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \

--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -30,7 +30,7 @@ fi
 # Believe it or not, if you don't do this srcds_run shits itself
 cd "${STEAMAPPDIR}"
 
-SERVER_SECURITY_FLAG="-secured";
+SERVER_SECURITY_FLAG="";
 
 if [ "$SRCDS_SECURED" -eq 0]; then
         SERVER_SECURITY_FLAG="-insecure";


### PR DESCRIPTION
In #24, @CakeNomLisa commented:
> I'm sorry, but that doesn't work as it is incorrect. The flag for disabling VAC on a source server is -insecure, not -insecured. Please fix.

This PR fixes this, also made the var empty instead of `-secured` as it does not exist.
Edit: I can't test this right now.
