### PR TITLE
Correct default SRCDS_MAPCYCLE

### DIFF
--- a/bookworm/Dockerfile
+++ b/bookworm/Dockerfile
@@ -59,7 +59,7 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_HOST_WORKSHOP_COLLECTION=0 \
         SRCDS_WORKSHOP_AUTHKEY="" \
 	SRCDS_CFG="server.cfg" \
-	SRCDS_MAPCYCLE="mapcycle_default.txt" \
+	SRCDS_MAPCYCLE="mapcycle.txt" \
 	SRCDS_SECURED=1
 
 # Switch to user


### PR DESCRIPTION
Make SRCDS_MAPCYCLE default consistent with vanilla TF2 game server mapcyclefile cvar default.