### PR TITLE
Add SRCDS_SDR_FAKEIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ SRCDS_WORKSHOP_AUTHKEY="" (required to load workshop maps)
 SRCDS_CFG="server.cfg"
 SRCDS_MAPCYCLE="mapcycle_default.txt" (value can be overwritten by tf/cfg/server.cfg)
 SRCDS_SECURED=1 (0 to start the server as insecured)
+SRCDS_SDR_FAKEIP=0 (1 to allow for the Steam Datagram Relay, hiding the server's IP)
 ```
 
 ## Config

--- a/bookworm/x32/Dockerfile
+++ b/bookworm/x32/Dockerfile
@@ -60,7 +60,8 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_WORKSHOP_AUTHKEY="" \
 	SRCDS_CFG="server.cfg" \
 	SRCDS_MAPCYCLE="mapcycle.txt" \
-	SRCDS_SECURED=1
+	SRCDS_SECURED=1 \
+	SRCDS_SDR_FAKEIP=0
 
 # Switch to user
 USER ${USER}

--- a/bookworm/x64/Dockerfile
+++ b/bookworm/x64/Dockerfile
@@ -58,7 +58,8 @@ ENV SRCDS_FPSMAX=300 \
         SRCDS_WORKSHOP_AUTHKEY="" \
 	SRCDS_CFG="server.cfg" \
 	SRCDS_MAPCYCLE="mapcycle.txt" \
-	SRCDS_SECURED=1
+	SRCDS_SECURED=1 \
+	SRCDS_SDR_FAKEIP=0
 
 # Switch to user
 USER ${USER}

--- a/etc/entry.sh
+++ b/etc/entry.sh
@@ -33,6 +33,12 @@ if [ "$SRCDS_SECURED" -eq 0 ]; then
         SERVER_SECURITY_FLAG="-insecure";
 fi
 
+SERVER_FAKEIP_FLAG="";
+
+if [ "$SRCDS_SDR_FAKEIP" -eq 1 ]; then
+        SERVER_FAKEIP_FLAG="-enablefakeip";
+fi
+
 bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         -steam_dir "${STEAMCMDDIR}" \
                         -steamcmd_script "${HOMEDIR}/${STEAMAPP}_update.txt" \
@@ -52,4 +58,5 @@ bash "${STEAMAPPDIR}/srcds_run" -game "${STEAMAPP}" -console -autoupdate \
                         -authkey "${SRCDS_WORKSHOP_AUTHKEY}" \
                         +servercfgfile "${SRCDS_CFG}" \
                         +mapcyclefile "${SRCDS_MAPCYCLE}" \
-                        ${SERVER_SECURITY_FLAG}
+                        ${SERVER_SECURITY_FLAG} \
+                        ${SERVER_FAKEIP_FLAG}

--- a/etc/entry_x64.sh
+++ b/etc/entry_x64.sh
@@ -33,6 +33,12 @@ if [ "$SRCDS_SECURED" -eq 0 ]; then
         SERVER_SECURITY_FLAG="-insecure";
 fi
 
+SERVER_FAKEIP_FLAG="";
+
+if [ "$SRCDS_SDR_FAKEIP" -eq 1 ]; then
+        SERVER_FAKEIP_FLAG="-enablefakeip";
+fi
+
 bash "${STEAMAPPDIR}/srcds_run_64" -game "${STEAMAPP}" -console -autoupdate \
                         -steam_dir "${STEAMCMDDIR}" \
                         -steamcmd_script "${HOMEDIR}/${STEAMAPP}_update.txt" \
@@ -52,4 +58,5 @@ bash "${STEAMAPPDIR}/srcds_run_64" -game "${STEAMAPP}" -console -autoupdate \
                         -authkey "${SRCDS_WORKSHOP_AUTHKEY}" \
                         +servercfgfile "${SRCDS_CFG}" \
                         +mapcyclefile "${SRCDS_MAPCYCLE}" \
-                        ${SERVER_SECURITY_FLAG}
+                        ${SERVER_SECURITY_FLAG} \
+                        ${SERVER_FAKEIP_FLAG}


### PR DESCRIPTION
As mentioned in #49, it would be very useful to have `-enablefakeip` accessible for server owners to use.

This was built and tested, and it works wonderfully.